### PR TITLE
Day Seven

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ My Advent of Code solutions for 2022! [Advent of Code](https://adventofcode.com/
 Our 2022 leaderboard for Advent of Code is `219042-9f06f774`. Enter the code on the [leaderboard page](https://adventofcode.com/2022/leaderboard/private) to join.
 
 # Solutions
-Each solution goes in a separate branch/PR, so you can review that day.
+Each solution goes in a [separate branch](https://github.com/ChaelCodes/advent-of-code-2022/branches/all)/PR, so you can review that day.
 
 - [Day One](https://github.com/ChaelCodes/advent-of-code-2022/pull/2)
 - [Day Two](https://github.com/ChaelCodes/advent-of-code-2022/pull/3)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Each solution goes in a separate branch/PR, so you can review that day.
 - [Day Four](https://github.com/ChaelCodes/advent-of-code-2022/pull/5)
 - [Day Five](https://github.com/ChaelCodes/advent-of-code-2022/pull/6)
 - [Day Six](https://github.com/ChaelCodes/advent-of-code-2022/pull/7)
+- [Day Seven](https://github.com/ChaelCodes/advent-of-code-2022/pull/8)
 
 # Previous Years
 

--- a/inputs/day_07.txt
+++ b/inputs/day_07.txt
@@ -1,0 +1,1135 @@
+$ cd /
+$ ls
+233998 glh.fcb
+184686 jzn
+dir qcznqph
+dir qtbprrq
+299692 rbssdzm.ccn
+dir vtb
+$ cd qcznqph
+$ ls
+32148 lhsrj.fnr
+dir lnj
+dir mtr
+dir mznnlph
+dir pdtpt
+24836 rsjcg.lrh
+dir vrj
+dir wrqcfl
+$ cd lnj
+$ ls
+12592 tlh
+$ cd ..
+$ cd mtr
+$ ls
+118870 twdhlmp.gbw
+$ cd ..
+$ cd mznnlph
+$ ls
+240977 fmmhnhtf
+dir gbhcnts
+dir gsbjrrd
+dir pmwcs
+dir qtbprrq
+286007 rhnjndsq.gst
+dir twdhlmp
+283716 twdhlmp.rpr
+$ cd gbhcnts
+$ ls
+dir fctrnwb
+dir gbhcnts
+46017 gft.hvm
+234925 gjsnzbtw.ncd
+dir nvnwh
+dir srslsjp
+dir swtlfsv
+66115 tgpmsb
+64086 tqnvb
+308270 tqwfpnbn.btp
+$ cd fctrnwb
+$ ls
+112643 qhcdd
+$ cd ..
+$ cd gbhcnts
+$ ls
+26196 cmttgsmm.bdn
+317410 fthqln
+dir lwshph
+32809 tdmfc
+dir tqcllnv
+dir twdhlmp
+$ cd lwshph
+$ ls
+214023 ctqvrzs.jvr
+104432 gbch
+dir gpqgrw
+105909 qshbtd.nml
+dir rhhsfbdd
+dir svvqh
+161439 tqnvb
+60152 twdhlmp.qzw
+$ cd gpqgrw
+$ ls
+dir mbsgrlld
+dir nhb
+dir qtbprrq
+$ cd mbsgrlld
+$ ls
+13247 tsztmlfg
+dir twdhlmp
+$ cd twdhlmp
+$ ls
+236804 mcrd
+$ cd ..
+$ cd ..
+$ cd nhb
+$ ls
+86570 gtvnbsv.zbr
+$ cd ..
+$ cd qtbprrq
+$ ls
+111178 npg.qph
+110775 tlh
+$ cd ..
+$ cd ..
+$ cd rhhsfbdd
+$ ls
+37729 fmmhnhtf
+263415 ljvwzj.btm
+$ cd ..
+$ cd svvqh
+$ ls
+185682 wlcl.fhs
+$ cd ..
+$ cd ..
+$ cd tqcllnv
+$ ls
+dir cbdj
+dir ccsfm
+55264 tqnvb
+267792 wlcl.fhs
+$ cd cbdj
+$ ls
+128247 fmmhnhtf
+dir mtnbs
+240520 ngmw.clj
+30569 qbqltr.lbw
+188801 zwdpp
+$ cd mtnbs
+$ ls
+dir bsfbrmh
+dir ftmnrwm
+$ cd bsfbrmh
+$ ls
+dir tltvzp
+$ cd tltvzp
+$ ls
+312469 dnst.sbm
+$ cd ..
+$ cd ..
+$ cd ftmnrwm
+$ ls
+278974 nlztftc.zhb
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ccsfm
+$ ls
+4017 wlcl.fhs
+$ cd ..
+$ cd ..
+$ cd twdhlmp
+$ ls
+dir qtbprrq
+$ cd qtbprrq
+$ ls
+dir tdpz
+$ cd tdpz
+$ ls
+210400 fmmhnhtf
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd nvnwh
+$ ls
+dir jlpbbds
+dir pphv
+285452 qtbprrq
+$ cd jlpbbds
+$ ls
+7058 vmrcqz
+$ cd ..
+$ cd pphv
+$ ls
+290310 msz.swz
+$ cd ..
+$ cd ..
+$ cd srslsjp
+$ ls
+dir nnz
+192902 twdhlmp.vgp
+$ cd nnz
+$ ls
+215711 tlh
+$ cd ..
+$ cd ..
+$ cd swtlfsv
+$ ls
+274236 frwncp.gff
+$ cd ..
+$ cd ..
+$ cd gsbjrrd
+$ ls
+dir dnst
+dir gbhcnts
+61000 gqdf
+175813 jvz
+dir ldqjzrtp
+$ cd dnst
+$ ls
+124352 dnst
+220618 mzsqzbfz.qfd
+134211 qmrvh
+dir qqlm
+dir qtbprrq
+223840 tlh
+dir twdhlmp
+24794 wfb.rtf
+$ cd qqlm
+$ ls
+113976 wlcl.fhs
+$ cd ..
+$ cd qtbprrq
+$ ls
+212775 qtbprrq.ngs
+$ cd ..
+$ cd twdhlmp
+$ ls
+308083 fzhd
+63311 wlcl.fhs
+$ cd ..
+$ cd ..
+$ cd gbhcnts
+$ ls
+dir dlvhzdbg
+$ cd dlvhzdbg
+$ ls
+305798 twdhlmp
+$ cd ..
+$ cd ..
+$ cd ldqjzrtp
+$ ls
+93085 dcvfpz.bjl
+264488 zssvm.wdp
+$ cd ..
+$ cd ..
+$ cd pmwcs
+$ ls
+125444 qtbprrq.tgl
+$ cd ..
+$ cd qtbprrq
+$ ls
+dir bjnctfv
+133127 fmmhnhtf
+dir gztmrrff
+dir qtbprrq
+$ cd bjnctfv
+$ ls
+dir cpwrcf
+dir fdjzsfc
+1223 gbhcnts.qvf
+272526 gbhcnts.sgs
+dir qnsdl
+dir snq
+dir tmjnvcbl
+dir vdjqsbr
+271339 wslnqh.rgr
+134589 zzqrbr.fcz
+$ cd cpwrcf
+$ ls
+143124 pdr
+$ cd ..
+$ cd fdjzsfc
+$ ls
+dir gbhcnts
+dir nqpbzvpq
+$ cd gbhcnts
+$ ls
+151265 jrdvt.fcg
+11872 tlh
+$ cd ..
+$ cd nqpbzvpq
+$ ls
+dir hpwhslq
+27858 ljvwzj.prq
+dir nzcnb
+$ cd hpwhslq
+$ ls
+136646 bqgj.wvw
+252823 ngmw.clj
+137072 tqnvb
+$ cd ..
+$ cd nzcnb
+$ ls
+99882 twdhlmp.grg
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd qnsdl
+$ ls
+8925 fmmhnhtf
+dir mnzqwfnh
+206990 vqgrhqgc
+$ cd mnzqwfnh
+$ ls
+271442 bmztfjlc.lzr
+$ cd ..
+$ cd ..
+$ cd snq
+$ ls
+25995 tqnvb
+$ cd ..
+$ cd tmjnvcbl
+$ ls
+dir gclzbvt
+$ cd gclzbvt
+$ ls
+dir jtfddbs
+$ cd jtfddbs
+$ ls
+10564 pdf.tsj
+32415 tlh
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd vdjqsbr
+$ ls
+256668 cwbd
+265036 fmmhnhtf
+$ cd ..
+$ cd ..
+$ cd gztmrrff
+$ ls
+52260 bdqcl.bdw
+dir lsss
+120102 tlh
+$ cd lsss
+$ ls
+13729 wlcl.fhs
+$ cd ..
+$ cd ..
+$ cd qtbprrq
+$ ls
+dir bttpq
+dir lcvgwpt
+$ cd bttpq
+$ ls
+216247 nnlv.dgl
+138688 wlcl.fhs
+$ cd ..
+$ cd lcvgwpt
+$ ls
+dir dth
+198570 tsqgm.zht
+dir zbcstsb
+$ cd dth
+$ ls
+dir cqmbtj
+120437 hdqp.vhq
+dir vpzn
+$ cd cqmbtj
+$ ls
+11882 sdngnzb
+$ cd ..
+$ cd vpzn
+$ ls
+dir jqbz
+271714 plcq.bfg
+$ cd jqbz
+$ ls
+dir qqhnfglj
+136307 stncbrm
+177843 tlh
+168253 tqnvb
+297085 wcn
+$ cd qqhnfglj
+$ ls
+197471 twdhlmp
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd zbcstsb
+$ ls
+298115 bvljmpc.gss
+308872 ljr.lzl
+201657 ngmw.clj
+170617 ppln
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd twdhlmp
+$ ls
+dir dbb
+277215 ngmw.clj
+310263 twdhlmp.wvs
+dir vsfrqsnl
+$ cd dbb
+$ ls
+258300 tqnvb
+$ cd ..
+$ cd vsfrqsnl
+$ ls
+dir gbhcnts
+12285 tlh
+$ cd gbhcnts
+$ ls
+248251 dnst.bcs
+91471 gbhcnts.ntr
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd pdtpt
+$ ls
+164477 flcgj.zwr
+dir ljvwzj
+51483 ljvwzj.htl
+dir pbtr
+dir qtbprrq
+dir rrhcsn
+$ cd ljvwzj
+$ ls
+dir nsq
+133318 qtbprrq.gqq
+166365 rnfbl.ljh
+130617 tlh
+16112 vbw
+$ cd nsq
+$ ls
+dir fwfcmfbz
+$ cd fwfcmfbz
+$ ls
+71451 zcc.ngn
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd pbtr
+$ ls
+dir qtbprrq
+$ cd qtbprrq
+$ ls
+117780 gjqbnrv.sdl
+$ cd ..
+$ cd ..
+$ cd qtbprrq
+$ ls
+269746 dld
+dir fcmbv
+42544 mlzvd.vcw
+165396 nbtlfm.vzq
+dir sbtl
+dir twdhlmp
+$ cd fcmbv
+$ ls
+202047 wdzcrg.mcg
+$ cd ..
+$ cd sbtl
+$ ls
+dir dbcdf
+dir fbz
+dir lvz
+dir ncnwbsdh
+dir rft
+23523 zphlfqf.phv
+$ cd dbcdf
+$ ls
+dir dhdw
+dir dvtjfhvm
+182513 lclmdwr
+63921 ngmw.clj
+dir qqmddq
+318020 tlh
+dir twdwfj
+83108 vmwlfdlf
+121901 wlcl.fhs
+$ cd dhdw
+$ ls
+dir qtbprrq
+dir twdhlmp
+dir wbllhmd
+$ cd qtbprrq
+$ ls
+111984 fhc.tzm
+$ cd ..
+$ cd twdhlmp
+$ ls
+277414 fwfqbb.dpj
+$ cd ..
+$ cd wbllhmd
+$ ls
+dir dnst
+dir jqz
+dir lbdclnfb
+dir ljvwzj
+dir mzfdg
+96340 ngmw.clj
+dir twdhlmp
+dir wmcfzznt
+147877 zwgvvd
+$ cd dnst
+$ ls
+310179 fmmhnhtf
+243908 twdhlmp
+$ cd ..
+$ cd jqz
+$ ls
+94739 twdhlmp
+$ cd ..
+$ cd lbdclnfb
+$ ls
+112509 ljvwzj
+$ cd ..
+$ cd ljvwzj
+$ ls
+28274 bshlmj.lzc
+84072 tlh
+283462 twdhlmp.ccd
+$ cd ..
+$ cd mzfdg
+$ ls
+282099 hbbrjc.jff
+63535 tlh
+$ cd ..
+$ cd twdhlmp
+$ ls
+283817 jltvl.tgl
+$ cd ..
+$ cd wmcfzznt
+$ ls
+294565 fmmhnhtf
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd dvtjfhvm
+$ ls
+292813 qgmvm.fsg
+$ cd ..
+$ cd qqmddq
+$ ls
+11670 dnst.btd
+241275 fmmhnhtf
+196615 fpnmptm
+dir nnzscbvw
+dir qnrr
+$ cd nnzscbvw
+$ ls
+250962 dflhdfz
+$ cd ..
+$ cd qnrr
+$ ls
+dir trzj
+$ cd trzj
+$ ls
+36993 gbhcnts.rdh
+273052 tlh
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd twdwfj
+$ ls
+162470 hfdhmbcq.hwz
+dir qtbprrq
+dir scjzbdsz
+2609 wlcl.fhs
+$ cd qtbprrq
+$ ls
+dir cfmglhwj
+103703 cscftrsr.jbs
+71160 dnst.rbw
+dir nrmp
+311716 qtbprrq
+$ cd cfmglhwj
+$ ls
+dir fmcmjfg
+$ cd fmcmjfg
+$ ls
+82998 ljvwzj.qbd
+8407 nhmmwwzl
+dir qtbprrq
+261949 tlh
+$ cd qtbprrq
+$ ls
+314421 hwqtl
+92593 zcdvf
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd nrmp
+$ ls
+94387 fmmhnhtf
+$ cd ..
+$ cd ..
+$ cd scjzbdsz
+$ ls
+6861 dgzhldd.dhs
+dir gbhcnts
+dir qtbprrq
+dir sfdl
+$ cd gbhcnts
+$ ls
+dir qdsrs
+$ cd qdsrs
+$ ls
+25165 ngmw.clj
+$ cd ..
+$ cd ..
+$ cd qtbprrq
+$ ls
+151403 tswd.hpf
+$ cd ..
+$ cd sfdl
+$ ls
+308622 jcmsnj
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd fbz
+$ ls
+dir dgjf
+dir qtbprrq
+$ cd dgjf
+$ ls
+254198 rvf.hfq
+$ cd ..
+$ cd qtbprrq
+$ ls
+dir frlj
+231222 njjfqgt.bph
+dir rjsw
+dir vjhzc
+$ cd frlj
+$ ls
+dir ljvwzj
+$ cd ljvwzj
+$ ls
+57572 ljvwzj.bvh
+$ cd ..
+$ cd ..
+$ cd rjsw
+$ ls
+131875 lbcq.rlc
+272908 mnfs
+$ cd ..
+$ cd vjhzc
+$ ls
+279363 fmmhnhtf
+238051 zdzbb.rfj
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd lvz
+$ ls
+289192 tqnvb
+dir twdhlmp
+$ cd twdhlmp
+$ ls
+dir wqtgwzdn
+$ cd wqtgwzdn
+$ ls
+283475 ghvpfl
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ncnwbsdh
+$ ls
+dir dfrdwfgm
+dir ljvwzj
+dir vgh
+$ cd dfrdwfgm
+$ ls
+279286 mrbwmws.nzd
+197337 nqgq.fhf
+248096 tqs.jfb
+35181 wlcl.fhs
+$ cd ..
+$ cd ljvwzj
+$ ls
+250455 gmph.scm
+147449 ljvwzj
+100189 qfr
+$ cd ..
+$ cd vgh
+$ ls
+244540 bzwrldnz.ldt
+235508 dzm
+dir gbhcnts
+dir qtv
+dir tvtwlt
+262356 wlcl.fhs
+$ cd gbhcnts
+$ ls
+160689 srvpbf.szt
+191895 tqnvb
+$ cd ..
+$ cd qtv
+$ ls
+9491 dnst.szf
+268602 ngmw.clj
+dir pbcrfzz
+39049 rzgqqvlt.nsm
+dir tfpl
+79589 wwcrv.ncv
+$ cd pbcrfzz
+$ ls
+dir stt
+256685 wlcl.fhs
+$ cd stt
+$ ls
+12650 jbdfwj
+$ cd ..
+$ cd ..
+$ cd tfpl
+$ ls
+92079 dfhj
+$ cd ..
+$ cd ..
+$ cd tvtwlt
+$ ls
+dir cqv
+$ cd cqv
+$ ls
+dir vdv
+$ cd vdv
+$ ls
+119483 fmmhnhtf
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd rft
+$ ls
+24341 bjhzvzp.flg
+dir glwdmdt
+$ cd glwdmdt
+$ ls
+288082 jdtlwrzh.wcj
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd twdhlmp
+$ ls
+dir gbhcnts
+154240 wlcl.fhs
+$ cd gbhcnts
+$ ls
+217462 ddzp
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd rrhcsn
+$ ls
+308440 dzbfl.vcg
+dir jbhcpdh
+238941 rnqdz
+dir szljjhc
+$ cd jbhcpdh
+$ ls
+dir bmg
+dir mdqplln
+dir twdhlmp
+dir zbt
+$ cd bmg
+$ ls
+dir djwfl
+dir gbhcnts
+dir ljvwzj
+142159 mwl.psh
+110681 rzmdgbng
+dir zqjbb
+$ cd djwfl
+$ ls
+dir dpfcrjl
+dir rqtz
+$ cd dpfcrjl
+$ ls
+206939 tlh
+$ cd ..
+$ cd rqtz
+$ ls
+232264 tlh
+$ cd ..
+$ cd ..
+$ cd gbhcnts
+$ ls
+186364 ngmw.clj
+248882 twdhlmp
+306411 wjqvlzp
+$ cd ..
+$ cd ljvwzj
+$ ls
+dir dgqw
+$ cd dgqw
+$ ls
+dir mpczlcrz
+dir qtbprrq
+dir twdhlmp
+dir zjsltthh
+$ cd mpczlcrz
+$ ls
+142906 gvd.nnz
+$ cd ..
+$ cd qtbprrq
+$ ls
+179566 fmmhnhtf
+309800 jhwwppc.vcp
+$ cd ..
+$ cd twdhlmp
+$ ls
+dir bhqjhjvp
+$ cd bhqjhjvp
+$ ls
+dir lmj
+dir qmcqggbl
+$ cd lmj
+$ ls
+275070 twdhlmp
+$ cd ..
+$ cd qmcqggbl
+$ ls
+dir mhgnpm
+$ cd mhgnpm
+$ ls
+dir rnzzqr
+$ cd rnzzqr
+$ ls
+126574 pgnlrjs.czj
+7567 tqnvb
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd zjsltthh
+$ ls
+dir twdhlmp
+$ cd twdhlmp
+$ ls
+198813 dnst.cqc
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd zqjbb
+$ ls
+dir czdvd
+94020 dnst
+46041 qtbprrq.pzm
+dir rcfvq
+dir rwj
+118305 vbcpcz
+48725 wlcl.fhs
+$ cd czdvd
+$ ls
+302317 tlf
+$ cd ..
+$ cd rcfvq
+$ ls
+dir cjws
+$ cd cjws
+$ ls
+dir dsgf
+dir fvqbhq
+203941 hgcbcvb
+9562 qqjh.mfh
+32161 qtbprrq.tgn
+225251 sbmpn
+dir sdhvcj
+$ cd dsgf
+$ ls
+dir cbwzg
+141466 ctpszzvn.qrq
+277153 ngmw.clj
+100681 vmdwgrp
+$ cd cbwzg
+$ ls
+dir nblvrbv
+$ cd nblvrbv
+$ ls
+129474 dlcbng.sgf
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd fvqbhq
+$ ls
+75755 fmmhnhtf
+229463 tlh
+$ cd ..
+$ cd sdhvcj
+$ ls
+306751 tqnvb
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd rwj
+$ ls
+130415 cjbz
+283701 rgsdtn
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd mdqplln
+$ ls
+169404 dvss.mvd
+105385 fmmhnhtf
+222834 jhzpwscp.sqg
+164293 jsqlprqn.vnp
+57167 pwpjfq.bmb
+dir qtbprrq
+$ cd qtbprrq
+$ ls
+62823 ljvwzj.flm
+252940 tlh
+$ cd ..
+$ cd ..
+$ cd twdhlmp
+$ ls
+dir dhvgfhc
+dir qrlq
+$ cd dhvgfhc
+$ ls
+dir vpldlp
+$ cd vpldlp
+$ ls
+279067 dnst.jfs
+9050 fmmhnhtf
+88586 mfbj.fgs
+$ cd ..
+$ cd ..
+$ cd qrlq
+$ ls
+dir qwwftl
+$ cd qwwftl
+$ ls
+103153 tnczww
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd zbt
+$ ls
+99657 fsq.rzj
+158138 gbfjfctj.bgg
+260423 tqnvb
+161379 trg
+$ cd ..
+$ cd ..
+$ cd szljjhc
+$ ls
+287080 stnp.lgp
+173682 wjzvglm.lfm
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd vrj
+$ ls
+129084 ngmw.clj
+250696 pdpzzbs
+$ cd ..
+$ cd wrqcfl
+$ ls
+dir bjlwb
+105899 gsvm
+dir jdnjpg
+178665 znnmmhqt.hth
+$ cd bjlwb
+$ ls
+207939 gbhcnts
+$ cd ..
+$ cd jdnjpg
+$ ls
+260418 tqnvb
+302144 twdhlmp.ghg
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd qtbprrq
+$ ls
+95562 fmmhnhtf
+dir plf
+dir qtbprrq
+306396 rqqmm.wvw
+dir wpfj
+$ cd plf
+$ ls
+dir fmftrbn
+20347 twb.zjd
+$ cd fmftrbn
+$ ls
+dir rfznrm
+$ cd rfznrm
+$ ls
+283327 rlzjcg
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd qtbprrq
+$ ls
+313931 ztmhrjc
+$ cd ..
+$ cd wpfj
+$ ls
+3969 wrbhb.jll
+$ cd ..
+$ cd ..
+$ cd vtb
+$ ls
+14260 fmmhnhtf
+dir gbhcnts
+dir lwcznw
+dir mhp
+dir pqcddzsf
+272267 qgh
+301727 rsjrn.wjg
+101787 vqscjb
+dir zvn
+$ cd gbhcnts
+$ ls
+7627 tqnvb
+$ cd ..
+$ cd lwcznw
+$ ls
+98498 dnst.tds
+dir gfh
+dir jdg
+dir llnl
+161511 mtmrr.hvb
+dir ppzwbgnz
+210908 qtbprrq
+dir tvhz
+$ cd gfh
+$ ls
+169547 mjjvvlqj.jmv
+$ cd ..
+$ cd jdg
+$ ls
+dir cthptwcf
+dir ljvwzj
+dir vnlndl
+$ cd cthptwcf
+$ ls
+98711 qwzwz.qct
+$ cd ..
+$ cd ljvwzj
+$ ls
+245473 zhptcmcr.fts
+$ cd ..
+$ cd vnlndl
+$ ls
+151466 ljvwzj
+285091 twdhlmp.mzv
+59067 vcdpbg.nmp
+$ cd ..
+$ cd ..
+$ cd llnl
+$ ls
+141508 phtmjj.qzl
+dir qtbprrq
+105151 tlh
+$ cd qtbprrq
+$ ls
+62020 hdzljht.fvq
+$ cd ..
+$ cd ..
+$ cd ppzwbgnz
+$ ls
+298940 pzdqzrn.zlz
+$ cd ..
+$ cd tvhz
+$ ls
+96628 hrzr
+$ cd ..
+$ cd ..
+$ cd mhp
+$ ls
+226604 mbdn.tbq
+dir ndgqtvhg
+$ cd ndgqtvhg
+$ ls
+55244 dnst
+dir sljbrmhb
+$ cd sljbrmhb
+$ ls
+32711 dnst
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd pqcddzsf
+$ ls
+dir shwrrq
+$ cd shwrrq
+$ ls
+dir dplcwvhg
+dir pvtpf
+dir qpsmgfjl
+247965 rrw.wwv
+dir vmrwpt
+$ cd dplcwvhg
+$ ls
+242534 fmmhnhtf
+202367 fzmt.qrw
+197586 ljvwzj.qgm
+dir stp
+dir zpz
+$ cd stp
+$ ls
+12921 mlcqtthb.jtd
+$ cd ..
+$ cd zpz
+$ ls
+235965 ngmw.clj
+$ cd ..
+$ cd ..
+$ cd pvtpf
+$ ls
+319563 rdspj.slv
+279577 vqpjzrdl.hhj
+$ cd ..
+$ cd qpsmgfjl
+$ ls
+131841 cqhrgc.cqz
+105373 fbnp
+$ cd ..
+$ cd vmrwpt
+$ ls
+176373 phgsdlnj.ggq
+$ cd ..
+$ cd ..
+$ cd ..
+$ cd zvn
+$ ls
+dir gbhcnts
+dir gfh
+dir ppqjzln
+dir qtbprrq
+$ cd gbhcnts
+$ ls
+156292 wlcl.fhs
+$ cd ..
+$ cd gfh
+$ ls
+189836 ljvwzj.wpt
+10416 zbnhzjvw.jct
+$ cd ..
+$ cd ppqjzln
+$ ls
+95088 sszd
+$ cd ..
+$ cd qtbprrq
+$ ls
+295187 hnnl
+292421 qtbprrq.ppg
+220281 wlcl.fhs

--- a/problems/day_07.md
+++ b/problems/day_07.md
@@ -1,0 +1,79 @@
+
+--- Day 7: No Space Left On Device ---
+
+You can hear birds chirping and raindrops hitting leaves as the expedition proceeds. Occasionally, you can even hear much louder sounds in the distance; how big do the animals get out here, anyway?
+
+The device the Elves gave you has problems with more than just its communication system. You try to run a system update:
+```
+$ system-update --please --pretty-please-with-sugar-on-top
+Error: No space left on device
+Perhaps you can delete some files to make space for the update?
+```
+You browse around the filesystem to assess the situation and save the resulting terminal output (your puzzle input). For example:
+```
+$ cd /
+$ ls
+dir a
+14848514 b.txt
+8504156 c.dat
+dir d
+$ cd a
+$ ls
+dir e
+29116 f
+2557 g
+62596 h.lst
+$ cd e
+$ ls
+584 i
+$ cd ..
+$ cd ..
+$ cd d
+$ ls
+4060174 j
+8033020 d.log
+5626152 d.ext
+7214296 k
+```
+The filesystem consists of a tree of files (plain data) and directories (which can contain other directories or files). The outermost directory is called /. You can navigate around the filesystem, moving into or out of directories and listing the contents of the directory you're currently in.
+
+Within the terminal output, lines that begin with `$` are **commands you executed**, very much like some modern computers:
+
+- `cd` means **change directory**. This changes which directory is the current directory, but the specific result depends on the argument:
+   - `cd x` moves in one level: it looks in the current directory for the directory named `x` and makes it the current directory.
+   - `cd ..` moves out one level: it finds the directory that contains the current directory, then makes that directory the current directory.
+   - `cd / `switches the current directory to the outermost directory, `/`.
+- `ls` means list. It prints out all of the files and directories immediately contained by the current directory:
+- `123 abc` means that the current directory contains a file named `abc` with size `123`.
+- `dir xyz` means that the current directory contains a directory named `xyz`.
+
+Given the commands and output in the example above, you can determine that the filesystem looks visually like this:
+```
+- / (dir)
+  - a (dir)
+    - e (dir)
+      - i (file, size=584)
+    - f (file, size=29116)
+    - g (file, size=2557)
+    - h.lst (file, size=62596)
+  - b.txt (file, size=14848514)
+  - c.dat (file, size=8504156)
+  - d (dir)
+    - j (file, size=4060174)
+    - d.log (file, size=8033020)
+    - d.ext (file, size=5626152)
+    - k (file, size=7214296)
+```
+Here, there are four directories: `/` (the outermost directory), `a` and `d` (which are in `/`), and `e` (which is in `a`). These directories also contain files of various sizes.
+
+Since the disk is full, your first step should probably be to find directories that are good candidates for deletion. To do this, you need to determine the *total size* of each directory. The total size of a directory is the sum of the sizes of the files it contains, directly or indirectly. (Directories themselves do not count as having any intrinsic size.)
+
+The total sizes of the directories above can be found as follows:
+
+The total size of directory `e` is `584` because it contains a single file `i` of size `584` and no other directories.
+The directory `a` has total size `94853` because it contains files `f` (size `29116`), `g` (size `2557`), and `h.lst` (size `62596`), plus file `i` indirectly (`a` contains `e` which contains `i`).
+Directory `d` has total size `24933642`.
+As the outermost directory,`/` contains every file. Its total size is `48381165`, the sum of the size of every file.
+To begin, find all of the directories with a total size of at most `100000`, then calculate the sum of their total sizes. In the example above, these directories are `a` and `e`; the sum of their total sizes is `95437` (`94853` + `584`). (As in this example, this process can count files more than once!)
+
+Find all of the directories with a total size of at most **100000**. **What is the sum of the total sizes of those directories?**

--- a/problems/day_07.md
+++ b/problems/day_07.md
@@ -77,3 +77,22 @@ As the outermost directory,`/` contains every file. Its total size is `48381165`
 To begin, find all of the directories with a total size of at most `100000`, then calculate the sum of their total sizes. In the example above, these directories are `a` and `e`; the sum of their total sizes is `95437` (`94853` + `584`). (As in this example, this process can count files more than once!)
 
 Find all of the directories with a total size of at most **100000**. **What is the sum of the total sizes of those directories?**
+
+--- Part Two ---
+
+Now, you're ready to choose a directory to delete.
+
+The total disk space available to the filesystem is 70000000. To run the update, you need unused space of at least 30000000. You need to find a directory you can delete that will free up enough space to run the update.
+
+In the example above, the total size of the outermost directory (and thus the total amount of used space) is 48381165; this means that the size of the unused space must currently be 21618835, which isn't quite the 30000000 required by the update. Therefore, the update still requires a directory with total size of at least 8381165 to be deleted before it can run.
+
+To achieve this, you have the following options:
+
+- Delete directory e, which would increase unused space by 584.
+- Delete directory a, which would increase unused space by 94853.
+- Delete directory d, which would increase unused space by 24933642.
+- Delete directory /, which would increase unused space by 48381165.
+
+Directories e and a are both too small; deleting them would not free up enough space. However, directories d and / are both big enough! Between these, choose the smallest: d, increasing unused space by 24933642.
+
+Find the smallest directory that, if deleted, would free up enough space on the filesystem to run the update. What is the total size of that directory?

--- a/solutions/day_07.rb
+++ b/solutions/day_07.rb
@@ -1,0 +1,99 @@
+class Day07
+  attr_accessor :file_tree, :location, :terminal_history, :part
+
+  COMMAND_REGEX = /^\$ (?<command>(cd|ls))\s?(?<directory>(\w+|\.\.|\/))?/
+  LS_OUTPUT_REGEX = /^(?<dir>dir)?(?<size>\d+)? (?<name>\w+\.?\w*)/
+
+  def initialize(part: 1, terminal_history: nil)
+    self.terminal_history = terminal_history || inputs
+    self.part = part
+    root = Directory.new name: '/', directories: [], files: [], size: 0
+    self.file_tree = root
+    self.location = root
+  end
+
+  Directory = Struct.new(:name, :directories, :files, :parent, :size, keyword_init: true) do
+    def child_directory(name)
+      if directories.none? { _1.name == name }
+        new_dir = Directory.new name: name, directories: [], files: [], parent: self, size: 0
+        directories << new_dir
+      end
+    end
+
+    def file(name, size)
+      if files.none? name
+        files << name
+        increase_size(size)
+      end
+    end
+
+    def find_directory(name)
+      raise if directories.none? { _1.name == name }
+      directories.find { _1.name == name }
+    end
+
+    def increase_size(size)
+      self.size += size
+      parent.increase_size(size) if parent
+    end
+  end
+
+  def inputs
+    day_match = self.class.name.match(/Day(?<number>\d+)/)
+    File.readlines("./inputs/day_#{day_match[:number]}.txt", chomp: true)
+  end
+
+  def parse_history(instruction)
+    parsed_command = instruction.match COMMAND_REGEX
+    parsed_ls_output = instruction.match LS_OUTPUT_REGEX 
+    run_command(parsed_command)
+    update_from_ls_output(parsed_ls_output)
+  end
+
+  def update_from_ls_output(parsed_ls_output)
+    return unless parsed_ls_output
+    if parsed_ls_output[:dir]
+      location.child_directory(parsed_ls_output[:name])
+    elsif parsed_ls_output[:size]
+      location.file(parsed_ls_output[:name], parsed_ls_output[:size].to_i)
+    end
+  end
+
+  def run_command(parsed_command)
+    return unless parsed_command
+    if parsed_command[:command] == "cd"
+      case parsed_command[:directory]
+      when '/'
+        self.location = file_tree
+      when '..'
+        self.location = location.parent
+      else
+        self.location = location.find_directory(parsed_command[:directory])
+      end
+    end
+  end
+
+  def traverse_tree(directories)
+    return 0 unless directories
+    dir_sizes = directories.map do |directory|
+      (directory.size > 100000 ? 0 : directory.size) + traverse_tree(directory.directories)
+    end.sum
+  end
+
+  def solve_part_1
+    terminal_history.each(&method(:parse_history))
+    traverse_tree(file_tree.directories)
+  end
+
+  def solve_part_2
+    terminal_history.count
+  end
+
+  def solve
+    if part == 1
+      solve_part_1
+    else
+      solve_part_2
+    end
+  end
+end

--- a/solutions/day_07.rb
+++ b/solutions/day_07.rb
@@ -3,6 +3,8 @@ class Day07
 
   COMMAND_REGEX = /^\$ (?<command>(cd|ls))\s?(?<directory>(\w+|\.\.|\/))?/
   LS_OUTPUT_REGEX = /^(?<dir>dir)?(?<size>\d+)? (?<name>\w+\.?\w*)/
+  TOTAL_DEVICE_STORAGE = 70_000_000
+  UPDATE_SPACE_REQUIRED = 30_000_000
 
   def initialize(part: 1, terminal_history: nil)
     self.terminal_history = terminal_history || inputs
@@ -80,13 +82,27 @@ class Day07
     end.sum
   end
 
+  def traverse_tree_for_candidates(directory, space_needed)
+    return unless directory.size >= space_needed
+    smallest_child = directory.directories.map do |dir|
+      if dir.size >= space_needed
+        traverse_tree_for_candidates(dir, space_needed)
+      end
+    end.compact.min_by(&:size)
+    smallest_child || directory
+  end
+
+
   def solve_part_1
     terminal_history.each(&method(:parse_history))
     traverse_tree(file_tree.directories)
   end
 
   def solve_part_2
-    terminal_history.count
+    terminal_history.each(&method(:parse_history))
+    unused_space = TOTAL_DEVICE_STORAGE - file_tree.size
+    space_needed_for_update = UPDATE_SPACE_REQUIRED - unused_space
+    traverse_tree_for_candidates(file_tree, space_needed_for_update).size
   end
 
   def solve

--- a/spec/day_07_spec.rb
+++ b/spec/day_07_spec.rb
@@ -133,10 +133,42 @@ RSpec.describe Day07 do
       end
     end
 
-    xcontext "for part 2" do
-      let(:solution) { described_class.new(part: 2) }
+    context "for part 2" do
+      let(:solution) { described_class.new(part: 2, terminal_history: terminal_history) }
 
-      it { is_expected.to eq 0 }
+      it { is_expected.to eq 12390492 }
+
+      context "with sample data" do
+        let(:terminal_history) do
+          [
+            "$ cd /",
+            "$ ls",
+            "dir a",
+            "14848514 b.txt",
+            "8504156 c.dat",
+            "dir d",
+            "$ cd a",
+            "$ ls",
+            "dir e",
+            "29116 f",
+            "2557 g",
+            "62596 h.lst",
+            "$ cd e",
+            "$ ls",
+            "584 i",
+            "$ cd ..",
+            "$ cd ..",
+            "$ cd d",
+            "$ ls",
+            "4060174 j",
+            "8033020 d.log",
+            "5626152 d.ext",
+            "7214296 k"
+          ]
+        end
+
+        it { is_expected.to eq 24933642 }
+      end
     end
   end
 end

--- a/spec/day_07_spec.rb
+++ b/spec/day_07_spec.rb
@@ -1,0 +1,142 @@
+RSpec.describe Day07 do
+  let(:solution) { described_class.new(terminal_history: terminal_history) }
+  let(:terminal_history) { nil }
+
+  describe "#inputs" do
+    subject { solution.inputs }
+
+    it { expect(subject.first).to eq "$ cd /" }
+    it { expect(subject.count).to eq 1135 }
+  end
+
+  describe "#parse_history" do
+    subject { solution.parse_history(instruction) }
+
+    context "move to root" do
+      let(:instruction) { "$ cd /" }
+
+      it "changes location to root" do
+        subject
+        expect(solution.location.name).to eq '/'
+      end
+    end
+
+    context "ls is noop" do
+      let(:instruction) { "$ ls" }
+
+      it "does nothing" do
+      end
+    end
+
+    context "dir a after ls" do
+      let(:instruction) { "dir a" }
+
+      it "creates a new directory under root" do
+        subject
+        expect(solution.file_tree.directories.map(&:name)).to include "a"
+      end
+    end
+
+    context "14848514 b.txt increases size" do
+      let(:instruction) {"14848514 b.txt" }
+
+      it "add file to list" do
+        subject
+        expect(solution.location.files).to include "b.txt"
+      end
+
+      it "increases the size of current node" do
+        subject
+        expect(solution.location.size).to eq 14848514
+      end
+
+      it "increases size of root node" do
+        subject
+        expect(solution.file_tree.size).to eq 14848514
+      end
+    end
+    
+    context "$ cd a" do
+      let(:instruction) { "$ cd a" }
+
+      before do
+        solution.parse_history("dir a")
+      end
+
+      it "changes location to a directory" do
+        subject
+        expect(solution.location.name).to eq "a"
+      end
+    end
+
+    context "14848514 b.txt increases size" do
+      let(:instruction) {"14848514 b.txt" }
+
+      before do
+        solution.parse_history("dir a")
+        solution.parse_history("cd a")
+      end
+
+      it "add file to list" do
+        subject
+        expect(solution.location.files).to include "b.txt"
+      end
+
+      it "increases the size of current node" do
+        subject
+        expect(solution.location.size).to eq 14848514
+      end
+
+      it "increases size of root node" do
+        subject
+        expect(solution.file_tree.size).to eq 14848514
+      end
+    end
+  end
+
+  describe "#solve" do
+    subject { solution.solve }
+
+    context "for part 1" do
+      it { is_expected.to eq 1490523 }
+
+      context "with sample data" do
+        let(:terminal_history) do
+          [
+            "$ cd /",
+            "$ ls",
+            "dir a",
+            "14848514 b.txt",
+            "8504156 c.dat",
+            "dir d",
+            "$ cd a",
+            "$ ls",
+            "dir e",
+            "29116 f",
+            "2557 g",
+            "62596 h.lst",
+            "$ cd e",
+            "$ ls",
+            "584 i",
+            "$ cd ..",
+            "$ cd ..",
+            "$ cd d",
+            "$ ls",
+            "4060174 j",
+            "8033020 d.log",
+            "5626152 d.ext",
+            "7214296 k"
+          ]
+        end
+
+        it { is_expected.to eq 95437 }
+      end
+    end
+
+    xcontext "for part 2" do
+      let(:solution) { described_class.new(part: 2) }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+end


### PR DESCRIPTION

--- Day 7: No Space Left On Device ---

You can hear birds chirping and raindrops hitting leaves as the expedition proceeds. Occasionally, you can even hear much louder sounds in the distance; how big do the animals get out here, anyway?

The device the Elves gave you has problems with more than just its communication system. You try to run a system update:
```
$ system-update --please --pretty-please-with-sugar-on-top
Error: No space left on device
Perhaps you can delete some files to make space for the update?
```
You browse around the filesystem to assess the situation and save the resulting terminal output (your puzzle input). For example:
```
$ cd /
$ ls
dir a
14848514 b.txt
8504156 c.dat
dir d
$ cd a
$ ls
dir e
29116 f
2557 g
62596 h.lst
$ cd e
$ ls
584 i
$ cd ..
$ cd ..
$ cd d
$ ls
4060174 j
8033020 d.log
5626152 d.ext
7214296 k
```
The filesystem consists of a tree of files (plain data) and directories (which can contain other directories or files). The outermost directory is called /. You can navigate around the filesystem, moving into or out of directories and listing the contents of the directory you're currently in.

Within the terminal output, lines that begin with `$` are **commands you executed**, very much like some modern computers:

- `cd` means **change directory**. This changes which directory is the current directory, but the specific result depends on the argument:
   - `cd x` moves in one level: it looks in the current directory for the directory named `x` and makes it the current directory.
   - `cd ..` moves out one level: it finds the directory that contains the current directory, then makes that directory the current directory.
   - `cd / `switches the current directory to the outermost directory, `/`.
- `ls` means list. It prints out all of the files and directories immediately contained by the current directory:
- `123 abc` means that the current directory contains a file named `abc` with size `123`.
- `dir xyz` means that the current directory contains a directory named `xyz`.

Given the commands and output in the example above, you can determine that the filesystem looks visually like this:
```
- / (dir)
  - a (dir)
    - e (dir)
      - i (file, size=584)
    - f (file, size=29116)
    - g (file, size=2557)
    - h.lst (file, size=62596)
  - b.txt (file, size=14848514)
  - c.dat (file, size=8504156)
  - d (dir)
    - j (file, size=4060174)
    - d.log (file, size=8033020)
    - d.ext (file, size=5626152)
    - k (file, size=7214296)
```
Here, there are four directories: `/` (the outermost directory), `a` and `d` (which are in `/`), and `e` (which is in `a`). These directories also contain files of various sizes.

Since the disk is full, your first step should probably be to find directories that are good candidates for deletion. To do this, you need to determine the *total size* of each directory. The total size of a directory is the sum of the sizes of the files it contains, directly or indirectly. (Directories themselves do not count as having any intrinsic size.)

The total sizes of the directories above can be found as follows:

The total size of directory `e` is `584` because it contains a single file `i` of size `584` and no other directories.
The directory `a` has total size `94853` because it contains files `f` (size `29116`), `g` (size `2557`), and `h.lst` (size `62596`), plus file `i` indirectly (`a` contains `e` which contains `i`).
Directory `d` has total size `24933642`.
As the outermost directory,`/` contains every file. Its total size is `48381165`, the sum of the size of every file.
To begin, find all of the directories with a total size of at most `100000`, then calculate the sum of their total sizes. In the example above, these directories are `a` and `e`; the sum of their total sizes is `95437` (`94853` + `584`). (As in this example, this process can count files more than once!)

Find all of the directories with a total size of at most **100000**. **What is the sum of the total sizes of those directories?**

--- Part Two ---

Now, you're ready to choose a directory to delete.

The total disk space available to the filesystem is 70000000. To run the update, you need unused space of at least 30000000. You need to find a directory you can delete that will free up enough space to run the update.

In the example above, the total size of the outermost directory (and thus the total amount of used space) is 48381165; this means that the size of the unused space must currently be 21618835, which isn't quite the 30000000 required by the update. Therefore, the update still requires a directory with total size of at least 8381165 to be deleted before it can run.

To achieve this, you have the following options:

- Delete directory e, which would increase unused space by 584.
- Delete directory a, which would increase unused space by 94853.
- Delete directory d, which would increase unused space by 24933642.
- Delete directory /, which would increase unused space by 48381165.

Directories e and a are both too small; deleting them would not free up enough space. However, directories d and / are both big enough! Between these, choose the smallest: d, increasing unused space by 24933642.

Find the smallest directory that, if deleted, would free up enough space on the filesystem to run the update. What is the total size of that directory?